### PR TITLE
fix: force generation of HTTPS URLs in templates

### DIFF
--- a/api.py
+++ b/api.py
@@ -11,6 +11,7 @@ templates = Jinja2Templates(directory="templates")
 
 @app.get("/")
 def serve(request: Request) -> HTMLResponse:
+    request.scope['scheme'] = 'https' # FIXME: force generation of `HTTPS` URLs
     return templates.TemplateResponse(request=request, name="index.html")
 
 @app.get("/preview-image")


### PR DESCRIPTION
Otherwise Jinja2's `url_for` generates HTTP URLs, which don't work for the `og:image`.